### PR TITLE
fix error while calling len of empty queryset

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -74,7 +74,7 @@ setup(
     description='Sphinxsearch database backend for django>=2.0',
     setup_requires=[
         'Django>=2.0,<2.2',
-        'mysqlclient>=1.4.2,<1.5.0'
+        'mysqlclient>=1.4.2,<1.5.0',
         'pytz'
     ],
 )

--- a/test-requires.txt
+++ b/test-requires.txt
@@ -2,3 +2,4 @@ mysqlclient==1.4.2
 jsonfield==2.0.2
 tblib==1.4.0
 pytz==2019.1
+Django>=2.1,<2.2

--- a/testproject/testapp/tests.py
+++ b/testproject/testapp/tests.py
@@ -1,8 +1,8 @@
-import re
 import sys
 from datetime import timedelta
 
 import pytz
+import re
 from django.conf import settings
 from django.db import connections
 from django.db.models import Sum, Q
@@ -116,6 +116,11 @@ class SphinxModelTestCase(SphinxModelTestCaseBase):
         qs = list(self.model.objects.extra(select={'const': 0},
                                            where=['const=0']))
         self.assertEqual(len(qs), 1)
+
+    def testLenOfEmptySet(self):
+        qs = self.model.objects.match("nonexistent")
+        self.assertEqual(qs.count(), 0)
+        self.assertEqual(len(qs[:0]), 0)
 
     def testGroupByExtraSelect(self):
         qs = self.model.objects.all()


### PR DESCRIPTION
While getting empty result set for search index Django admin calls `len(qs[:0])` which raises error:
```
TypeError at /admin/search/content/
'NoneType' object is not subscriptable

        select, klass_info, annotation_col_map = (compiler.select, compiler.klass_info,
                                                  compiler.annotation_col_map)
        model_cls = klass_info['model'] # HERE
        select_fields = klass_info['select_fields']
        model_fields_start, model_fields_end = select_fields[0], select_
```