### PR TITLE
Django-2.2 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ env:
   matrix:
     - DJANGO=2.0
     - DJANGO=2.1
+    - DJANGO=2.2
 
 before_install:
   - curl http://sphinxsearch.com/files/sphinx-3.1.1-612d99f-linux-amd64-glibc2.12.tar.gz > sphinx-3.1.1.tar.gz
@@ -14,7 +15,7 @@ before_install:
 
 
 install:
-  - pip install Django==$DJANGO
+  - pip install Django~=$DJANGO
   - pip install -r test-requires.txt
   - pip install codecov
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![PyPI version](https://badge.fury.io/py/django_sphinxsearch.svg)](http://badge.fury.io/py/django_sphinxsearch)
 
 * Not a [django_sphinx_db](https://github.com/smartfile/django-sphinx-db) fork
-* `Django==2.0` supported
+* `Django>=2.0,<2.3` supported
 
 ## Installation and usage
 

--- a/setup.py
+++ b/setup.py
@@ -73,7 +73,7 @@ setup(
     author_email='zimbler@gmail.com',
     description='Sphinxsearch database backend for django>=2.0',
     setup_requires=[
-        'Django>=2.0,<2.2',
+        'Django>=2.0,<2.3',
         'mysqlclient>=1.4.2,<1.5.0',
         'pytz'
     ],

--- a/sphinxsearch/backend/sphinx/base.py
+++ b/sphinxsearch/backend/sphinx/base.py
@@ -156,9 +156,6 @@ class DatabaseWrapper(base.DatabaseWrapper):
         self.features = SphinxFeatures(self)
         self.validation = SphinxValidation(self)
 
-    def _start_transaction_under_autocommit(self):
-        raise NotImplementedError()
-
     @cached_property
     def mysql_version(self):
         # Django>=1.10 makes if differently

--- a/testproject/settings.py
+++ b/testproject/settings.py
@@ -112,3 +112,5 @@ USE_TZ = True
 # https://docs.djangoproject.com/en/1.8/howto/static-files/
 
 STATIC_URL = '/static/'
+
+SILENCED_SYSTEM_CHECKS = ['models.E028']

--- a/testproject/testapp/tests.py
+++ b/testproject/testapp/tests.py
@@ -679,6 +679,8 @@ class EscapingTestCase(SphinxModelTestCaseBase):
 
 
 class DatabaseOperationsTestCase(SphinxModelTestCaseBase):
+    databases = ['default', 'cloned']
+
     def test_clone_db(self):
         if self.cloned_index:  # pragma: no cover
             # cloned index is the same test itself


### PR DESCRIPTION
* Updated setup.py and test-requires
* Added Django-2.2 to test matrix
* Removed "NotImplemented" from set_autocommit for sphinx: autocommit mode is supported since 1.x but can be used only with RT indices.