### PR TITLE
Pin mysqlclient max version to 1.4.2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -74,7 +74,7 @@ setup(
     description='Sphinxsearch database backend for django>=2.0',
     setup_requires=[
         'Django>=2.0,<2.3',
-        'mysqlclient>=1.4.2,<1.5.0',
+        'mysqlclient==1.4.2',
         'pytz'
     ],
 )


### PR DESCRIPTION
 Pin mysqlclient version to 1.4.2 due to https://github.com/PyMySQL/mysqlclient-python/issues/376