### PR TITLE
remove jsonfield dependency as non-compatible with django-3.0

### DIFF
--- a/sphinxsearch/fields.py
+++ b/sphinxsearch/fields.py
@@ -1,4 +1,5 @@
 import datetime
+import json
 import time
 
 import pytz
@@ -89,3 +90,17 @@ class SphinxMultiField(models.IntegerField):
 
 class SphinxMulti64Field(SphinxMultiField):
     pass
+
+
+class SphinxJSONField(models.TextField):
+
+    # noinspection PyUnusedLocal,PyMethodMayBeStatic
+    def from_db_value(self, value, expression, connection):
+        if not isinstance(value, str) or value is None:
+            return value
+        return json.loads(value)
+
+    def to_python(self, value):
+        if value is None:
+            return value
+        return json.dumps(value)

--- a/test-requires.txt
+++ b/test-requires.txt
@@ -1,5 +1,4 @@
 mysqlclient==1.4.6
-jsonfield==2.0.2
 tblib==1.4.0
 pytz==2019.3
 Django==2.2.7

--- a/testproject/testapp/models.py
+++ b/testproject/testapp/models.py
@@ -1,25 +1,13 @@
 # coding: utf-8
 
 # $Id: $
-import json
 
 from datetime import datetime
+
 from django.db import models
 
-from jsonfield.fields import JSONField
-
-from sphinxsearch import sql
 from sphinxsearch import models as spx_models
-
-
-class Django10CompatJSONField(JSONField):
-
-    # noinspection PyMethodMayBeStatic,PyUnusedLocal
-    def from_db_value(self, value, expression, connection, context):
-        # In Django-1.10 python value is loaded in this method
-        if value is None:
-            return None
-        return json.loads(value)
+from sphinxsearch import sql
 
 
 class FieldMixin(spx_models.SphinxModel):
@@ -34,7 +22,7 @@ class FieldMixin(spx_models.SphinxModel):
     attr_string = models.CharField(max_length=32, default='')
     attr_multi = spx_models.SphinxMultiField(default=[])
     attr_multi_64 = spx_models.SphinxMulti64Field(default=[])
-    attr_json = Django10CompatJSONField(default={})
+    attr_json = spx_models.SphinxJSONField(default={})
     attr_bool = models.BooleanField(default=False)
 
 
@@ -69,7 +57,7 @@ class OverridenSphinxModel(models.Model, metaclass=sql.SphinxModelBase):
     attr_string = models.CharField(max_length=32, default='')
     attr_multi = spx_models.SphinxMultiField(default=[])
     attr_multi_64 = spx_models.SphinxMulti64Field(default=[])
-    attr_json = Django10CompatJSONField(default={})
+    attr_json = spx_models.SphinxJSONField(default={})
     attr_bool = models.BooleanField(default=False)
 
 
@@ -103,7 +91,7 @@ class ModelWithAllDbColumnFields(spx_models.SphinxModel):
                                              db_column='_attr_multi')
     attr_multi_64 = spx_models.SphinxMulti64Field(default=[],
                                                   db_column='_attr_multi_64')
-    attr_json = Django10CompatJSONField(default={}, db_column='_attr_json')
+    attr_json = spx_models.SphinxJSONField(default={}, db_column='_attr_json')
     attr_bool = models.BooleanField(default=False, db_column='_attr_bool')
 
 


### PR DESCRIPTION
[jsonfield](https://pypi.org/project/jsonfield/) latest supported version is Django-1.11 and is incompatible with Django-3.0. So sphinxsearch should provide own jsonfield implementation.